### PR TITLE
fix(ci): use recommended syntax for multiline outputs

### DIFF
--- a/.github/workflows/docs_updater.yml
+++ b/.github/workflows/docs_updater.yml
@@ -19,8 +19,13 @@ jobs:
       - name: Get latest commit information
         id: commit_info
         run: |
-          echo "commit_message=$(git log -1 --pretty=%B)" >> $GITHUB_OUTPUT
-          echo "commit_diff=$(git diff HEAD~1 HEAD)" >> $GITHUB_OUTPUT
+          echo 'commit_message<<EOF' >> "$GITHUB_OUTPUT"
+          echo "$(git log -1 --pretty=%B)" >> "$GITHUB_OUTPUT"
+          echo 'EOF' >> "$GITHUB_OUTPUT"
+
+          echo 'commit_diff<<EOF' >> "$GITHUB_OUTPUT"
+          echo "$(git diff HEAD~1 HEAD)" >> "$GITHUB_OUTPUT"
+          echo 'EOF' >> "$GITHUB_OUTPUT"
 
       - name: Run AI Documentation Agent
         if: "!contains(steps.commit_info.outputs.commit_message, '[DEVDOCS]')"


### PR DESCRIPTION
Updates the `docs_updater` workflow to use the recommended "heredoc" syntax for setting multiline outputs in GitHub Actions.

This resolves the "Invalid format" error that occurred when commit messages contained newlines. This is the official, modern way to handle multiline strings for job outputs.